### PR TITLE
chore(cli): mise à jour du helper CLI avec start/finish

### DIFF
--- a/bin/git-tbd
+++ b/bin/git-tbd
@@ -18,11 +18,13 @@ declare -A BRANCH_ICONS=(
 
 function print_help() {
   echo -e "${BOLD}git-tbd${RESET} - CLI pour workflow Trunk-Based Development\n"
-  echo "Usage:"
-  echo "  git-tbd start <feature-name>   → Crée une branche feature/<feature-name>"
-  echo "  git-tbd finish                 → Merge dans main + suppression de la branche"
-  echo "  git-tbd sync                   → Met à jour la branche courante depuis main"
-  echo "  git-tbd help                   → Affiche cette aide"
+  echo "Usage :"
+  echo "  git-tbd start              → Sélection interactive du type de branche à créer"
+  echo "  git-tbd finish             → Merge dans main + suppression de la branche"
+  echo "  git-tbd sync               → Met à jour la branche courante depuis main"
+  echo "  git-tbd pr                 → Ouvre une Pull Request automatiquement"
+  echo "  git-tbd bump <type>        → Bump la version (major, minor, patch)"
+  echo "  git-tbd help               → Affiche cette aide"
 }
 
 create_branch() {


### PR DESCRIPTION
Cette PR met à jour la commande `print_help` pour refléter les évolutions récentes :

- Ajout de `start` (interactive avec fzf)
- Ajout de `finish` (intelligente selon le type de branche)
- Nettoyage des anciennes entrées obsolètes (start_feature, etc.)

🎯 Objectif : garder une aide claire et à jour pour l’utilisateur.