### PR TITLE
🐛 fix: use eval() to parse fully named parameters to start command (PR #41)

### DIFF
--- a/lib/commands/start.sh
+++ b/lib/commands/start.sh
@@ -15,8 +15,10 @@ select_branch_type() {
     done
     
     local sorted_options
-    mapfile -t sorted_options < <(printf '%s\n' "${options[@]}" | sort)
-    options=("${sorted_options[@]}")
+    sorted_options=()
+    while IFS= read -r line; do
+      sorted_options+=("$line")
+    done < <(printf '%s\n' "${options[@]}" | sort)
     
     selected_type=$(printf "%s\n" "${options[@]}" | \
       fzf --prompt="🎯 Type de branche : " \
@@ -39,7 +41,10 @@ select_branch_type() {
     print_message ""
     
     local types_sorted
-    mapfile -t types_sorted < <(printf "%s\n" "${!BRANCH_ICONS[@]}" | sort)
+    types_sorted=()
+    while IFS= read -r line; do
+      types_sorted+=("$line")
+    done < <(printf '%s\n' "${!BRANCH_ICONS[@]}" | sort)
     
     local i=1
     for type in "${types_sorted[@]}"; do
@@ -102,6 +107,10 @@ start() {
     
     full_branch_name="${type}/${name}"
   fi
+
+  # Validations finales
+  log_debug "Avant validation: type='$type', name='$name', full_branch_name='$full_branch_name'"
+
 
   # Validations finales
   if ! is_valid_branch_type "$type"; then

--- a/lib/core/validation.sh
+++ b/lib/core/validation.sh
@@ -47,27 +47,33 @@ normalize_branch_name() {
 parse_branch_input() {
   # Parse une entrée type "feature/login" en type + name
   local input="$1"
-  local -n out_type=$2
-  local -n out_name=$3
+  local var_type="$2"
+  local var_name="$3"
+
+  log_debug "parse_branch_input() input='$input'"
 
   if [[ "$input" != */* ]]; then
     log_error "Format de branche invalide : '$input'. Attendu : type/nom"
     return 1
   fi
 
-  local type="${input%%/*}"
-  local name="${input#*/}"
+  local parsed_type="${input%%/*}"
+  local parsed_name="${input#*/}"
 
-  log_debug "parse_branch_input() → type: $type, name: $name"
+  log_debug "parse_branch_input() → type='$parsed_type', name='$parsed_name'"
 
-  if [[ -z "${BRANCH_ICONS[$type]}" ]]; then
-    log_warn "Type de branche non reconnu : '$type'"
+  if [[ -z "${BRANCH_ICONS[$parsed_type]}" ]]; then
+    log_warn "Type de branche non reconnu : '$parsed_type'"
     log_info "💡 Types disponibles : ${!BRANCH_ICONS[*]}"
     return 1
   fi
-  
-  out_type="$type"
-  out_name="$name"
+
+  # Utiliser declare -g pour assigner au scope global
+  eval "$var_type=\$parsed_type"
+  eval "$var_name=\$parsed_name"
+
+  log_debug "parse_branch_input() après assign: ${var_type}='${!var_type}', ${var_name}='${!var_name}'"
+
   return 0
 }
 


### PR DESCRIPTION
- fix: use eval() to parse fully named parameters to start command